### PR TITLE
Get on with forEach

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = inject
 
 
 function inject(element, callback) {
-  callback = callback || noop
+  callback = typeof callback === 'function' ? callback : noop
 
   var url = element.getAttribute('src')
   if (!url) return


### PR DESCRIPTION
Make able to do `elements.forEach(inject)`.
forEach passes int as a second arg, so it's worth ignoring non-fn callback.
@hughsk 
